### PR TITLE
Added client_id OAuth 2.0 support to CDSHooks service

### DIFF
--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksProperties.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksProperties.java
@@ -17,6 +17,16 @@ public class CdsHooksProperties {
 		this.enabled = enabled;
 	}
 
+	private String clientIdHeaderName;
+
+	public String getClientIdHeaderName() {
+		return clientIdHeaderName;
+	}
+
+	public void setClientIdHeaderName(String clientIdHeaderName) {
+		this.clientIdHeaderName = clientIdHeaderName;
+	}
+
 	private FhirServer fhirServer = new FhirServer();
 
 	public FhirServer getFhirServer() {
@@ -27,7 +37,7 @@ public class CdsHooksProperties {
 		this.fhirServer = fhirServer;
 	}
 
-	public class FhirServer {
+	public static class FhirServer {
 		private Integer maxCodesPerQuery;
 
 		public Integer getMaxCodesPerQuery() {
@@ -79,7 +89,7 @@ public class CdsHooksProperties {
 		this.prefetch = prefetch;
 	}
 
-	public class Prefetch {
+	public static class Prefetch {
 		private Integer maxUriLength;
 
 		public Integer getMaxUriLength() {

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/dstu3/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/dstu3/CdsHooksServlet.java
@@ -154,8 +154,12 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 				useServerData = new BooleanType(false);
 				remoteDataEndpoint = new Endpoint().setAddress(cdsHooksRequest.fhirServer);
 				if (cdsHooksRequest.fhirAuthorization != null) {
-					remoteDataEndpoint.addHeader(cdsHooksRequest.fhirAuthorization.tokenType + ": "
-							+ cdsHooksRequest.fhirAuthorization.accessToken);
+					remoteDataEndpoint.addHeader(cdsHooksRequest.fhirAuthorization.tokenType
+						+ ": " + cdsHooksRequest.fhirAuthorization.accessToken);
+					if (cdsHooksRequest.fhirAuthorization.subject != null) {
+						remoteDataEndpoint.addHeader(this.getProviderConfiguration().getClientIdHeaderName()
+							+ ": " + cdsHooksRequest.fhirAuthorization.subject);
+					}
 				}
 			}
 			Bundle data = CdsHooksUtil.getPrefetchResources(cdsHooksRequest);

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
@@ -7,24 +7,26 @@ import ca.uhn.fhir.rest.api.SearchStyleEnum;
 
 public class ProviderConfiguration {
 
-	public static final ProviderConfiguration DEFAULT_PROVIDER_CONFIGURATION = new ProviderConfiguration(true, null,
-			SearchStyleEnum.GET, 8000, false, null);
+	public static final ProviderConfiguration DEFAULT_PROVIDER_CONFIGURATION = new ProviderConfiguration(true, 64,
+			SearchStyleEnum.GET, 8000, false, 5, "client_id");
 
-	private Integer maxCodesPerQuery;
-	private SearchStyleEnum searchStyle;
-	private boolean expandValueSets;
-	private Integer queryBatchThreshold;
-	private int maxUriLength;
-	private boolean cqlLoggingEnabled;
+	private final Integer maxCodesPerQuery;
+	private final SearchStyleEnum searchStyle;
+	private final boolean expandValueSets;
+	private final Integer queryBatchThreshold;
+	private final Integer maxUriLength;
+	private final String clientIdHeaderName;
+	private final boolean cqlLoggingEnabled;
 
 	public ProviderConfiguration(boolean expandValueSets, Integer maxCodesPerQuery, SearchStyleEnum searchStyle,
-			int maxUriLength, boolean cqlLoggingEnabled, Integer queryBatchThreshold) {
+			Integer maxUriLength, boolean cqlLoggingEnabled, Integer queryBatchThreshold, String clientIdHeaderName) {
 		this.maxCodesPerQuery = maxCodesPerQuery;
 		this.searchStyle = searchStyle;
 		this.expandValueSets = expandValueSets;
 		this.maxUriLength = maxUriLength;
 		this.cqlLoggingEnabled = cqlLoggingEnabled;
 		this.queryBatchThreshold = queryBatchThreshold;
+		this.clientIdHeaderName = clientIdHeaderName;
 	}
 
 	public ProviderConfiguration(CdsHooksProperties cdsProperties, CqlProperties cqlProperties) {
@@ -33,6 +35,7 @@ public class ProviderConfiguration {
 		this.searchStyle = cdsProperties.getFhirServer().getSearchStyle();
 		this.maxUriLength = cdsProperties.getPrefetch().getMaxUriLength();
 		this.queryBatchThreshold = cdsProperties.getFhirServer().getQueryBatchThreshold();
+		this.clientIdHeaderName = cdsProperties.getClientIdHeaderName();
 		this.cqlLoggingEnabled = cqlProperties.getOptions().getCqlEngineOptions().isDebugLoggingEnabled();
 	}
 
@@ -50,8 +53,12 @@ public class ProviderConfiguration {
 
 	public Integer getQueryBatchThreshold() { return this.queryBatchThreshold; }
 
-	public int getMaxUriLength() {
+	public Integer getMaxUriLength() {
 		return this.maxUriLength;
+	}
+
+	public String getClientIdHeaderName() {
+		return this.clientIdHeaderName;
 	}
 
 	public boolean getCqlLoggingEnabled() {

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
@@ -158,8 +158,12 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 				useServerData = new BooleanType(false);
 				remoteDataEndpoint = new Endpoint().setAddress(cdsHooksRequest.fhirServer);
 				if (cdsHooksRequest.fhirAuthorization != null) {
-					remoteDataEndpoint.addHeader(cdsHooksRequest.fhirAuthorization.tokenType + ": "
-							+ cdsHooksRequest.fhirAuthorization.accessToken);
+					remoteDataEndpoint.addHeader(cdsHooksRequest.fhirAuthorization.tokenType
+						+ ": " + cdsHooksRequest.fhirAuthorization.accessToken);
+					if (cdsHooksRequest.fhirAuthorization.subject != null) {
+						remoteDataEndpoint.addHeader(this.getProviderConfiguration().getClientIdHeaderName()
+							+ ": " + cdsHooksRequest.fhirAuthorization.subject);
+					}
 				}
 			}
 			Bundle data = CdsHooksUtil.getPrefetchResources(cdsHooksRequest);

--- a/plugin/cds-hooks/src/main/resources/application.yaml
+++ b/plugin/cds-hooks/src/main/resources/application.yaml
@@ -2,6 +2,7 @@ hapi:
    fhir:
       cdshooks:
          enabled: true
+         clientIdHeaderName: client_id
          fhirserver:
             expandValueSets: true
             maxCodesPerQuery: 64

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -99,10 +99,11 @@ hapi:
       ## CDS Hook Settings
       cdshooks:
          enabled: true
+         clientIdHeaderName: client_id
          fhirserver:
-#            expandValueSets: true
-#            maxCodesPerQuery: 64
-#            queryBatchThreshold: 10
+            expandValueSets: true
+            maxCodesPerQuery: 64
+            queryBatchThreshold: 5
             searchStyle: GET
          prefetch:
             maxUriLength: 8000


### PR DESCRIPTION
The OAuth 2.0 `client_id` header may be required to request access to patient data. This PR provides the default `client_id` header name along with a way to configure that to be environment-specific (like Epic-Client-ID for instance). See the [CDSHooks docs](https://cds-hooks.hl7.org/1.0/#passing-the-access-token-to-the-cds-service) for more information, especially the `subject` element in the fhirAuthorization request parameter.