### PR TITLE
Fhirdal searchbyurl add version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-core</artifactId>
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-external</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-core</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-test</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-external</artifactId>

--- a/plugin/case-reporting/pom.xml
+++ b/plugin/case-reporting/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-case-reporting</artifactId>
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cql</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/plugin/cds-hooks/pom.xml
+++ b/plugin/cds-hooks/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-cds-hooks</artifactId>
@@ -12,22 +12,22 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cql</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cr</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-security</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cpg</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugin/cpg/pom.xml
+++ b/plugin/cpg/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-cpg</artifactId>
@@ -12,13 +12,13 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cql</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-security</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/plugin/cql/pom.xml
+++ b/plugin/cql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-cql</artifactId>

--- a/plugin/cr/pom.xml
+++ b/plugin/cr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>cqf-ruler-cr</artifactId>
 	<dependencies>
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cql</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/JpaCRFhirDal.java
+++ b/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/JpaCRFhirDal.java
@@ -3,15 +3,12 @@ package org.opencds.cqf.ruler.cr;
 import ca.uhn.fhir.rest.param.TokenParam;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
-import org.hl7.fhir.r4.model.CanonicalType;
-import org.hl7.fhir.r4.model.Measure;
 import org.opencds.cqf.cql.evaluator.fhir.dal.FhirDal;
 
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.UriParam;
-import org.opencds.cqf.ruler.utility.Searches;
 
 @SuppressWarnings("unchecked")
 public class JpaCRFhirDal implements FhirDal {

--- a/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/JpaCRFhirDal.java
+++ b/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/JpaCRFhirDal.java
@@ -1,13 +1,17 @@
 package org.opencds.cqf.ruler.cr;
 
+import ca.uhn.fhir.rest.param.TokenParam;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.Measure;
 import org.opencds.cqf.cql.evaluator.fhir.dal.FhirDal;
 
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.UriParam;
+import org.opencds.cqf.ruler.utility.Searches;
 
 @SuppressWarnings("unchecked")
 public class JpaCRFhirDal implements FhirDal {
@@ -54,7 +58,27 @@ public class JpaCRFhirDal implements FhirDal {
 
 	@Override
 	public Iterable<IBaseResource> searchByUrl(String theResourceType, String theUrl) {
-		return this.daoRegistry.getResourceDao(theResourceType)
-				.search(SearchParameterMap.newSynchronous().add("url", new UriParam(theUrl))).getAllResources();
+		if (theUrl.contains("|")){
+			var urlSplit = theUrl.split("\\|");
+			var urlBase = urlSplit[0];
+			var urlVersion = urlSplit[1];
+
+			return this.daoRegistry.getResourceDao(theResourceType)
+				.search(
+					SearchParameterMap
+						.newSynchronous()
+						.add("url", new UriParam(urlBase))
+						.add("version", new TokenParam(urlVersion))
+				)
+				.getAllResources();
+		}
+		else {
+			return this.daoRegistry.getResourceDao(theResourceType)
+				.search(
+					SearchParameterMap
+						.newSynchronous()
+						.add("url", new UriParam(theUrl)))
+				.getAllResources();
+		}
 	}
 }

--- a/plugin/dev-tools/pom.xml
+++ b/plugin/dev-tools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-dev-tools</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-plugin</artifactId>
@@ -25,12 +25,12 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-core</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-external</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-test</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/plugin/ra/pom.xml
+++ b/plugin/ra/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-ra</artifactId>
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cr</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>

--- a/plugin/sdc/pom.xml
+++ b/plugin/sdc/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-sdc</artifactId>

--- a/plugin/security/pom.xml
+++ b/plugin/security/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler-plugin</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-security</artifactId>
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-dev-tools</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.opencds.cqf.ruler</groupId>
 	<artifactId>cqf-ruler</artifactId>
-	<version>0.13.0</version>
+	<version>0.14.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>cqf-ruler</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-server</artifactId>
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-core</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -230,37 +230,37 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-case-reporting</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cds-hooks</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cpg</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cql</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-cr</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-dev-tools</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 
@@ -268,19 +268,19 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-ra</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-sdc</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-security</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opencds.cqf.ruler</groupId>
 		<artifactId>cqf-ruler</artifactId>
-		<version>0.13.0</version>
+		<version>0.14.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cqf-ruler-test</artifactId>
@@ -103,12 +103,12 @@
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-core</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opencds.cqf.ruler</groupId>
 			<artifactId>cqf-ruler-external</artifactId>
-			<version>0.13.0</version>
+			<version>0.14.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
bug in fhirDal's searchByURL where users that had canonical references were prevented from having them recognized properly.

adding next snapshot for project

leaving cql support versions at release until 3.0 is ready:

```
<cqframework.version>2.7.0</cqframework.version>
		<cql-engine.version>2.7.0</cql-engine.version>
		<cql-evaluator.version>2.6.0</cql-evaluator.version>
```