### PR TITLE
CDS Hooks R4 Indicator Resolution

### DIFF
--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
@@ -250,6 +250,17 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 						if (action.hasDescription()) {
 							card.setDetail(action.getDescription());
 						}
+						if (action.hasPriority()) {
+							String indicator;
+							switch (action.getPriority().toCode()) {
+								case "routine": indicator = "info"; break;
+								case "urgent": indicator = "warning"; break;
+								case "stat": indicator = "critical"; break;
+								default: throw new IllegalArgumentException(
+									"Invalid priority code: " + action.getPriority().toCode());
+							}
+							card.setIndicator(indicator);
+						}
 						if (action.hasDocumentation()) {
 							card.setSource(resolveSource(action));
 						}


### PR DESCRIPTION
Updated cds hooks processing to check for action.priority codes to set card indicator value. This rationale for this functionality/mapping can be found [here](http://hl7.org/fhir/R4/clinicalreasoning-cds-on-fhir.html#evaluation) (navigate to the mapping table in that section with headers "CDS Hooks Element" and "FHIR Resource Mapping")


