### PR TITLE
Hapi 6.6.1 update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/hapi-fhir-jpaserver-starter"]
 	path = external/hapi-fhir-jpaserver-starter
 	url = https://github.com/hapifhir/hapi-fhir-jpaserver-starter.git
-	branch = 6.7.6-snapshot-server
+	branch = 6.6.1-cr-updates

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
 		<!-- Dependency Versions -->
 		<flexmark_version>0.62.2</flexmark_version>
-		<hapi_version>6.7.8-SNAPSHOT</hapi_version>
+		<hapi_version>6.6.1</hapi_version>
 		<javax.version>8.0.1</javax.version>
 		<junit_version>5.8.2</junit_version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Current master is pointed at 6.7.x-snapshot of hapi-fhir, in order to perform a release we will require the latest release jar of hapi-fhir which is 6.6.1. This also updated external jpaserver-starter project to point at a build with hapi 6.6.1