### PR TITLE
Adding needed mssql dependency for SQL Server support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,12 @@
 			</dependency>
 
 			<dependency>
+				<groupId>com.microsoft.sqlserver</groupId>
+				<artifactId>mssql-jdbc</artifactId>
+				<version>8.4.1.jre11</version>
+			</dependency>
+
+			<dependency>
 				<groupId>com.vladsch.flexmark</groupId>
 				<artifactId>flexmark</artifactId>
 				<version>${flexmark_version}</version>


### PR DESCRIPTION
The added dependency is needed to support SQL Server users. It is a nice QoL enhancement for users that we may want to expand upon and document. 